### PR TITLE
Swift dispatch optimisations

### DIFF
--- a/StableApplication/Properties/PropertyCell.swift
+++ b/StableApplication/Properties/PropertyCell.swift
@@ -8,6 +8,6 @@
 
 import UIKit
 
-protocol PropertyCell where Self: UITableViewCell {
+protocol PropertyCell: class where Self: UITableViewCell {
     func configure(using property: Property)
 }


### PR DESCRIPTION
I'm not sure, but most likely crash linked with swift optimisation ways for dispatch methods .
Compiler cannot understand which type of dispatch to use.
If implicitly point, that PropertyCell is class protocol, everything works.