### PR TITLE
Crash fix.

### DIFF
--- a/StableApplication/Properties/PropertyCell.swift
+++ b/StableApplication/Properties/PropertyCell.swift
@@ -8,6 +8,6 @@
 
 import UIKit
 
-protocol PropertyCell where Self: UITableViewCell {
+protocol PropertyCell: NSObjectProtocol where Self: UITableViewCell {
     func configure(using property: Property)
 }


### PR DESCRIPTION
Protocol with such type constraint MUST be inherited from NSObjectProtocol.